### PR TITLE
Update platform-metrics.md

### DIFF
--- a/platform-metrics.md
+++ b/platform-metrics.md
@@ -25,7 +25,7 @@ Currently, {{site.data.keyword.mon_full_notm}} integration is available for {{si
 | `Dallas` | `Dallas` |
 | `Frankfurt` | `Frankfurt` |
 | `London` | `London` |
-| `Madrid` | `Frankfurt` Currently, Cloud Monitoring in Madrid is routed to Frankfurt until Madrid support is enabled.|
+| `Madrid` | `Madrid` |
 | `Osaka` | `Osaka` |
 | `Paris` | `Paris` |
 | `São Paulo` | `São Paulo` |


### PR DESCRIPTION
Starting on October 30th, auditing events, platform logs, and/or platform metrics originating in Madrid will now be sent to the Observability service in Madrid as opposed to Frankfurt as it was being routed before.